### PR TITLE
Fix Pub badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ https://www.khronos.org/registry/OpenGL/specs/es/3.2/es_spec_3.2.pdf
 https://www.khronos.org/registry/EGL/specs/eglspec.1.5.pdf
 
 https://learnopengl.com/Getting-started/Hello-Triangle
+
+[Pub]: pub.dev/packages/flutter_web_gl


### PR DESCRIPTION
The Pub badge in the README is currently broken because it is missing its hyperlink.

![image](https://user-images.githubusercontent.com/19204050/109822965-62edf080-7c2f-11eb-8758-82c8b93a6a14.png)
