### PR TITLE
Update lib_egl.dart

### DIFF
--- a/lib/lib_egl.dart
+++ b/lib/lib_egl.dart
@@ -29,7 +29,7 @@ void loadEGL() {
     if (Platform.isMacOS || Platform.isIOS) {
       _libEGL = LibEGL(DynamicLibrary.process());
     } else {
-      _libEGL = LibEGL(DynamicLibrary.open(resolveDylibPath('libEGL')));
+      _libEGL = LibEGL(DynamicLibrary.open(resolveDylibPath('EGL')));
     }
   }
 }


### PR DESCRIPTION
Drop prefix for EGL path, it is included automatically except for windows where it is not needed.